### PR TITLE
TAVC-removeBrk from Number of shares purchased page

### DIFF
--- a/conf/messages
+++ b/conf/messages
@@ -1118,7 +1118,7 @@ validation.error.InvestorShareIssueDate.Future = Investor previous shares issued
 
 #Number of shares purchased
 page.investors.numberOfSharesPurchased.title = How many shares were issued to this {0} on {1}?
-page.investors.numberOfSharesPurchased.heading = How many shares were issued to this {0} on <br/>{1}?
+page.investors.numberOfSharesPurchased.heading = How many shares were issued to this {0} on {1}?
 
 #Previous ShareHolding Nominal Value
 page.investors.previousShareHoldingNominalValue.title = What was the nominal value for each share in this previous issue?

--- a/test/views/seis/NumberOfSharesPurchasedSpec.scala
+++ b/test/views/seis/NumberOfSharesPurchasedSpec.scala
@@ -54,7 +54,7 @@ class NumberOfSharesPurchasedSpec extends ViewSpec with DateFormatter{
       }
 
      "have the correct heading" in {
-        document.select("h1").text() shouldBe Html(Messages("page.investors.numberOfSharesPurchased.title", "company", "TODO")).toString()
+        document.select("h1").text() shouldBe Messages("page.investors.numberOfSharesPurchased.title", "company", "TODO")
       }
 
       "have a form posting to the correct route" in {


### PR DESCRIPTION
Following discussion with UX - this brk is being removed to make consistent when wrapping content in title or header