### PR TITLE
TAVC-3337 problems routing to other pages without fixing initially

### DIFF
--- a/app/controllers/eis/ShareIssueDateController.scala
+++ b/app/controllers/eis/ShareIssueDateController.scala
@@ -43,30 +43,18 @@ trait ShareIssueDateController extends FrontendController with AuthorisedAndEnro
 
   val show = AuthorisedAndEnrolled.async { implicit user => implicit request =>
 
-    def routeRequest(backUrl: Option[String]) = {
-      if (backUrl.isDefined) {
         s4lConnector.fetchAndGetFormData[ShareIssueDateModel](KeystoreKeys.shareIssueDate).map {
-          case Some(data) => Ok(ShareIssueDate(shareIssueDateForm.fill(data), backUrl.getOrElse("")))
-          case None => Ok(ShareIssueDate(shareIssueDateForm, backUrl.getOrElse("")))
+          case Some(data) => Ok(ShareIssueDate(shareIssueDateForm.fill(data)))
+          case None => Ok(ShareIssueDate(shareIssueDateForm))
         }
       }
-      else Future.successful(Redirect(routes.QualifyBusinessActivityController.show()))
-    }
-    for {
-      link <- ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkShareIssueDate, s4lConnector)
-      route <- routeRequest(link)
-    } yield route
-  }
+
 
   val submit = AuthorisedAndEnrolled.async { implicit user => implicit request =>
     shareIssueDateForm.bindFromRequest().fold(
       formWithErrors => {
-
-        ControllerHelpers.getSavedBackLink(KeystoreKeys.backLinkShareIssueDate, s4lConnector).flatMap {
-          case Some(data) => Future.successful(BadRequest(ShareIssueDate(formWithErrors, data)))
-          case None => Future.successful(Redirect(routes.QualifyBusinessActivityController.show()))
-        }
-      },
+        Future.successful(BadRequest(ShareIssueDate(formWithErrors)))
+        },
       validFormData => {
         s4lConnector.saveFormData(KeystoreKeys.shareIssueDate, validFormData)
         Future.successful(Redirect(routes.GrossAssetsController.show()))

--- a/app/views/eis/companyDetails/ShareIssueDate.scala.html
+++ b/app/views/eis/companyDetails/ShareIssueDate.scala.html
@@ -2,11 +2,11 @@
 @import uk.gov.hmrc.play.views.html.helpers.form
 @import views.html.helpers.{externalLink, backButtonWithProgress, errorSummary, formInlineDateInput}
 
-@(shareIssueDateForm: Form[ShareIssueDateModel],backLink:String)(implicit request: Request[_], messages: Messages)
+@(shareIssueDateForm: Form[ShareIssueDateModel])(implicit request: Request[_], messages: Messages)
 
 @main_template(Messages("page.companyDetails.ShareIssueDate.title")) {
 
-    @backButtonWithProgress(backLink, Messages("common.section.progress.details.one"))
+    @backButtonWithProgress(controllers.eis.routes.CommercialSaleController.show().url, Messages("common.section.progress.details.one"))
 
     @errorSummary(shareIssueDateForm, "share-issue-date", "shareIssueDay")
 

--- a/test/controllers/eis/ShareIssueDateControllerSpec.scala
+++ b/test/controllers/eis/ShareIssueDateControllerSpec.scala
@@ -50,7 +50,7 @@ class ShareIssueDateControllerSpec extends BaseSpec {
     }
   }
 
-  def setupMocks(shareIssueDateModel: Option[ShareIssueDateModel] = None, backLink: Option[String] = None): Unit = {
+  def setupMocks(shareIssueDateModel: Option[ShareIssueDateModel] = None): Unit = {
     when(mockS4lConnector.fetchAndGetFormData[ShareIssueDateModel](Matchers.eq(KeystoreKeys.shareIssueDate))
       (Matchers.any(), Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(shareIssueDateModel))
@@ -58,8 +58,6 @@ class ShareIssueDateControllerSpec extends BaseSpec {
     when(mockS4lConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(CacheMap("", Map())))
 
-    when(mockS4lConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkShareIssueDate))
-      (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(backLink))
 
     when(mockS4lConnector.saveFormData(Matchers.eq(KeystoreKeys.backLinkShareIssueDate),
       Matchers.any())(Matchers.any(), Matchers.any(), Matchers.any()))
@@ -68,27 +66,19 @@ class ShareIssueDateControllerSpec extends BaseSpec {
   }
 
   "Sending a GET request to ShareIssueDateController when authenticated and enrolled" should {
-    "return a 200 when something is fetched from keystore and back link returned" in {
-      setupMocks(Some(shareIssuetDateModel), Some("/test/test"))
-      mockEnrolledRequest(eisSchemeTypesModel)
-      showWithSessionAndAuth(TestController.show())(
-        result => status(result) shouldBe OK
-      )
-    }
 
-    "return a 200 when something is fetched from keystore and back link is None" in {
-      setupMocks(Some(shareIssuetDateModel), None)
+    "return a 200 when something is fetched from keystore" in {
+      setupMocks(Some(shareIssuetDateModel))
       mockEnrolledRequest(eisSchemeTypesModel)
       showWithSessionAndAuth(TestController.show())(
         result => {
-          status(result) shouldBe SEE_OTHER
-          redirectLocation(result) shouldBe Some(controllers.eis.routes.QualifyBusinessActivityController.show().url)
+          status(result) shouldBe OK
         }
       )
     }
 
     "provide an empty model and return a 200 when nothing is fetched using keystore" in {
-      setupMocks(None, Some("/test/test/"))
+      setupMocks(None)
       mockEnrolledRequest(eisSchemeTypesModel)
       showWithSessionAndAuth(TestController.show())(
         result => status(result) shouldBe OK
@@ -117,7 +107,7 @@ class ShareIssueDateControllerSpec extends BaseSpec {
 
   "Sending an invalid form submission with validation errors to the ShareIssueDateController when authenticated and enrolled" should {
     "return a bad request" in {
-      setupMocks(None, Some("/test/test"))
+      setupMocks(None)
       mockEnrolledRequest(eisSchemeTypesModel)
       val formInput = Seq(
         "shareIssueDay" -> "",

--- a/test/views/eis/ShareIssueDateSpec.scala
+++ b/test/views/eis/ShareIssueDateSpec.scala
@@ -44,7 +44,7 @@ class ShareIssueDateSpec extends ViewSpec {
     override lazy val enrolmentConnector = mockEnrolmentConnector
   }
 
-  def setupMocks(shareIssueDateModel: Option[ShareIssueDateModel] = None, backLink: Option[String] = None): Unit = {
+  def setupMocks(shareIssueDateModel: Option[ShareIssueDateModel] = None): Unit = {
     when(mockS4lConnector.fetchAndGetFormData[ShareIssueDateModel](Matchers.eq(KeystoreKeys.shareIssueDate))
       (Matchers.any(), Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(shareIssueDateModel))
@@ -52,8 +52,6 @@ class ShareIssueDateSpec extends ViewSpec {
     when(mockS4lConnector.saveFormData(Matchers.any(), Matchers.any())(Matchers.any(), Matchers.any(), Matchers.any()))
       .thenReturn(Future.successful(CacheMap("", Map())))
 
-    when(mockS4lConnector.fetchAndGetFormData[String](Matchers.eq(KeystoreKeys.backLinkShareIssueDate))
-      (Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(Future.successful(backLink))
 
     when(mockS4lConnector.saveFormData(Matchers.eq(KeystoreKeys.backLinkShareIssueDate),
       Matchers.any())(Matchers.any(), Matchers.any(), Matchers.any()))
@@ -64,7 +62,7 @@ class ShareIssueDateSpec extends ViewSpec {
 
     "Verify that Share Issue Date page contains the correct elements when a valid ShareIssueDateModel is passed with expected url" in new Setup {
       val document: Document = {
-        setupMocks(Some(shareIssuetDateModel), Some(testUrl))
+        setupMocks(Some(shareIssuetDateModel))
         val result = TestController.show.apply(authorisedFakeRequest)
         Jsoup.parse(contentAsString(result))
       }
@@ -78,33 +76,33 @@ class ShareIssueDateSpec extends ViewSpec {
         Messages("page.companyDetails.ShareIssueDate.location")
 
       document.getElementById("next").text() shouldBe Messages("common.button.snc")
-      document.body.getElementById("back-link").attr("href") shouldEqual testUrl
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show().url
       document.body.getElementById("progress-section").text shouldBe  Messages("common.section.progress.details.one")
     }
 
-    "Verify that Share Issue Date page contains the correct elements when a valid ShareIssueDateModel is passed with alternate url" in new Setup {
-      val document: Document = {
-        setupMocks(Some(shareIssuetDateModel), Some(testUrlOther))
-        val result = TestController.show.apply(authorisedFakeRequest)
-        Jsoup.parse(contentAsString(result))
-      }
-      document.title() shouldBe Messages("page.companyDetails.ShareIssueDate.title")
-      document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.ShareIssueDate.heading")
-      document.body.getElementsByClass("form-hint").text should include(Messages("common.date.hint.example"))
-      document.body.getElementById("shareIssueDay").parent.text shouldBe Messages("common.date.fields.day")
-      document.body.getElementById("shareIssueMonth").parent.text shouldBe Messages("common.date.fields.month")
-      document.body.getElementById("shareIssueYear").parent.text shouldBe Messages("common.date.fields.year")
-      document.body.getElementById("date-of-shareIssue-where-to-find").parent.text should include
-      Messages("page.companyDetails.ShareIssueDate.location")
-
-      document.getElementById("next").text() shouldBe Messages("common.button.snc")
-      document.body.getElementById("back-link").attr("href") shouldEqual testUrlOther
-      document.body.getElementById("progress-section").text shouldBe  Messages("common.section.progress.details.one")
-    }
+//    "Verify that Share Issue Date page contains the correct elements when a valid ShareIssueDateModel is passed with alternate url" in new Setup {
+//      val document: Document = {
+//        setupMocks(Some(shareIssuetDateModel), Some(testUrlOther))
+//        val result = TestController.show.apply(authorisedFakeRequest)
+//        Jsoup.parse(contentAsString(result))
+//      }
+//      document.title() shouldBe Messages("page.companyDetails.ShareIssueDate.title")
+//      document.getElementById("main-heading").text() shouldBe Messages("page.companyDetails.ShareIssueDate.heading")
+//      document.body.getElementsByClass("form-hint").text should include(Messages("common.date.hint.example"))
+//      document.body.getElementById("shareIssueDay").parent.text shouldBe Messages("common.date.fields.day")
+//      document.body.getElementById("shareIssueMonth").parent.text shouldBe Messages("common.date.fields.month")
+//      document.body.getElementById("shareIssueYear").parent.text shouldBe Messages("common.date.fields.year")
+//      document.body.getElementById("date-of-shareIssue-where-to-find").parent.text should include
+//      Messages("page.companyDetails.ShareIssueDate.location")
+//
+//      document.getElementById("next").text() shouldBe Messages("common.button.snc")
+//      document.body.getElementById("back-link").attr("href") shouldEqual testUrlOther
+//      document.body.getElementById("progress-section").text shouldBe  Messages("common.section.progress.details.one")
+//    }
 
     "Verify that the Share Issue Date page contains the correct elements when an invalid ShareIssueDateModel is passed" in new Setup {
       val document: Document = {
-        setupMocks(None, Some(testUrl))
+        setupMocks(None)
         val result = TestController.submit.apply(authorisedFakeRequest)
         Jsoup.parse(contentAsString(result))
       }
@@ -117,9 +115,12 @@ class ShareIssueDateSpec extends ViewSpec {
       document.body.getElementById("date-of-shareIssue-where-to-find").parent.text should include
         Messages("page.companyDetails.ShareIssueDate.location")
       document.getElementById("next").text() shouldBe Messages("common.button.snc")
-      document.body.getElementById("back-link").attr("href") shouldEqual testUrl
+      document.body.getElementById("back-link").attr("href") shouldEqual routes.CommercialSaleController.show().url
       document.body.getElementById("progress-section").text shouldBe  Messages("common.section.progress.details.one")
       document.getElementById("error-summary-display").hasClass("error-summary--show")
+      document.getElementById("error-summary-heading").text shouldBe Messages("common.error.summary.heading")
+      document.getElementById("shareIssueDay-error-summary").text shouldBe Messages("validation.error.DateNotEntered")
+      document.getElementsByClass("error-notification").text shouldBe Messages("validation.error.DateNotEntered")
 
     }
 


### PR DESCRIPTION
Renoving Back Link functions from ShareIssueDate as not required for EIS and enable routing from Commercial Sale page